### PR TITLE
Update hello workflow and remove test workflow

### DIFF
--- a/.github/workflows/hello.yml
+++ b/.github/workflows/hello.yml
@@ -1,21 +1,12 @@
 name: Hello Workflow
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       message:
         description: 'Enter your message'
         required: true
         type: string
-      choice:
-        description: 'Choose an option'
-        required: true
-        type: choice
-        options:
-          - Option A
-          - Option B
-          - Option C
-
 jobs:
   print-inputs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changed .github/workflows/hello.yml to use workflow_call and removed the 'choice' input. Deleted the .github/workflows/test file to clean up unused workflows.

## Summary by Sourcery

Convert the Hello workflow to a callable workflow and clean up unused workflows

Enhancements:
- Update hello.yml to use workflow_call trigger instead of workflow_dispatch and remove the 'choice' input

Chores:
- Delete the unused test workflow file